### PR TITLE
Set flash data automatically into view variables

### DIFF
--- a/docs/ServerSideSetup.md
+++ b/docs/ServerSideSetup.md
@@ -99,7 +99,7 @@ class AppController extends Controller
 
 ### Flash messages
 
-When working with CakePHP we often use Flash messages to set one-time notification message to notify user that particular action has succeeded or not. This plugin makes it easier to work with Flash messages, because you don't have to do anything extra use make flash messages work.
+When working with CakePHP we often use Flash messages to set one-time notification message to acknowledge user that particular action has succeeded or not. This plugin makes it easier to work with Flash messages, because you don't have to do anything extra make flash messages work.
 
 To pass flash data into the front-end component, you simply have to set flash message as you normally would:
 

--- a/docs/ServerSideSetup.md
+++ b/docs/ServerSideSetup.md
@@ -97,6 +97,18 @@ class AppController extends Controller
 
 **Note:** You must have to call `beforeRender` method of `InertiaResponseTrait`, otherwise the inertia response won't work as expected.
 
+### Flash messages
+
+When working with CakePHP we often use Flash messages to set one-time notification message to notify user that particular action has succeeded or not. This plugin makes it easier to work with Flash messages, because you don't have to do anything extra use make flash messages work.
+
+To pass flash data into the front-end component, you simply have to set flash message as you normally would:
+
+```php
+$this->Flash->success('It worked!');
+```
+
+That's it! The flash data will automatically pass to component as a `Array` for you to use.
+
 ---
 
 [< Installation](Installation.md) | [Client-side Setup >](ClientSideSetup.md)

--- a/src/Controller/InertiaResponseTrait.php
+++ b/src/Controller/InertiaResponseTrait.php
@@ -17,6 +17,8 @@ trait InertiaResponseTrait
         }
 
         $this->setViewBuilderClass();
+
+        $this->setFlashData();
     }
 
     /**
@@ -70,5 +72,19 @@ trait InertiaResponseTrait
         }
 
         return false;
+    }
+
+    /**
+     * Sets flash data, and deletes after setting it.
+     *
+     * @return void
+     */
+    protected function setFlashData()
+    {
+        $session = $this->getRequest()->getSession();
+
+        $this->set('flash', $session->read('Flash.flash'));
+
+        $session->delete('Flash');
     }
 }

--- a/tests/TestCase/Controller/UsersControllerTest.php
+++ b/tests/TestCase/Controller/UsersControllerTest.php
@@ -123,13 +123,13 @@ class UsersControllerTest extends TestCase
         $this->assertContentType('text/html');
     }
 
-    public function testItSetsFlashDataIntoProps()
+    public function testItSetsSuccessFlashDataIntoProps()
     {
         $this->configRequest([
             'headers' => ['X-Inertia' => 'true'],
         ]);
 
-        $this->get('/users/check-flash-data');
+        $this->get('/users/set-success-flash');
         $responseArray = json_decode($this->_getBodyAsString(), true);
 
         $this->assertResponseOk();
@@ -139,6 +139,27 @@ class UsersControllerTest extends TestCase
                 'message' => 'User saved successfully.',
                 'key' => 'flash',
                 'element' => 'Flash/success',
+                'params' => [],
+            ],
+        ], $responseArray['props']['flash']);
+    }
+
+    public function testItSetsErrorFlashDataIntoProps()
+    {
+        $this->configRequest([
+            'headers' => ['X-Inertia' => 'true'],
+        ]);
+
+        $this->get('/users/set-error-flash');
+        $responseArray = json_decode($this->_getBodyAsString(), true);
+
+        $this->assertResponseOk();
+        $this->assertArrayHasKey('flash', $responseArray['props']);
+        $this->assertEquals([
+            [
+                'message' => 'Something went wrong!',
+                'key' => 'flash',
+                'element' => 'Flash/error',
                 'params' => [],
             ],
         ], $responseArray['props']['flash']);

--- a/tests/TestCase/Controller/UsersControllerTest.php
+++ b/tests/TestCase/Controller/UsersControllerTest.php
@@ -79,7 +79,7 @@ class UsersControllerTest extends TestCase
                 'postsCount' => 2,
             ],
         ], JSON_PRETTY_PRINT);
-        $this->assertEquals($expected, (string)$this->_response->getBody());
+        $this->assertEquals($expected, $this->_getBodyAsString());
     }
 
     public function testItRedirectsWithSeeOtherResponseCode()
@@ -121,5 +121,26 @@ class UsersControllerTest extends TestCase
 
         $this->assertResponseCode(500);
         $this->assertContentType('text/html');
+    }
+
+    public function testItSetsFlashDataIntoProps()
+    {
+        $this->configRequest([
+            'headers' => ['X-Inertia' => 'true'],
+        ]);
+
+        $this->get('/users/check-flash-data');
+        $responseArray = json_decode($this->_getBodyAsString(), true);
+
+        $this->assertResponseOk();
+        $this->assertArrayHasKey('flash', $responseArray['props']);
+        $this->assertEquals([
+            [
+                'message' => 'User saved successfully.',
+                'key' => 'flash',
+                'element' => 'Flash/success',
+                'params' => [],
+            ],
+        ], $responseArray['props']['flash']);
     }
 }

--- a/tests/test_app/src/Controller/AppController.php
+++ b/tests/test_app/src/Controller/AppController.php
@@ -28,9 +28,6 @@ class AppController extends Controller
         $this->set('app', [
             'name' => 'InertiaTestApp',
         ]);
-        $this->set('flash', function () {
-            return ['message' => null];
-        });
         $this->set('auth', function () {
             return ['user' => null];
         });

--- a/tests/test_app/src/Controller/UsersController.php
+++ b/tests/test_app/src/Controller/UsersController.php
@@ -60,8 +60,13 @@ class UsersController extends AppController
         echo $fail;
     }
 
-    public function checkFlashData()
+    public function setSuccessFlash()
     {
         $this->Flash->success('User saved successfully.');
+    }
+
+    public function setErrorFlash()
+    {
+        $this->Flash->error('Something went wrong!');
     }
 }

--- a/tests/test_app/src/Controller/UsersController.php
+++ b/tests/test_app/src/Controller/UsersController.php
@@ -59,4 +59,9 @@ class UsersController extends AppController
     {
         echo $fail;
     }
+
+    public function checkFlashData()
+    {
+        $this->Flash->success('User saved successfully.');
+    }
 }


### PR DESCRIPTION
This plugin will not automatically pass flash array to view variables to pass it into front-end components. Now users do not need to set flash data manually.

Currently it only passes `flash` key from `Flash` session variable set via `success()` or `error()` methods from [`FlashComponent`](https://book.cakephp.org/3/en/controllers/components/flash.html#setting-flash-messages).