### PR TITLE
Lazy data evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Set flash data automatically into view variables ([#9](https://github.com/ishanvyas22/cakephp-inertiajs/pull/9))
+- Lazy evaluate props ([#10](https://github.com/ishanvyas22/cakephp-inertiajs/pull/10))
 
 ### Changed
 - Use `Psr\Http\Message\ResponseInterface` instead of `Cake\Http\Response` concrete class ([ab61375](https://github.com/ishanvyas22/cakephp-inertiajs/commit/ab61375e19cdc7612b434de8b3cf78be6788ec26))

--- a/src/Controller/InertiaResponseTrait.php
+++ b/src/Controller/InertiaResponseTrait.php
@@ -81,10 +81,15 @@ trait InertiaResponseTrait
      */
     protected function setFlashData()
     {
+        /** @var \Cake\Http\Session */
         $session = $this->getRequest()->getSession();
 
-        $this->set('flash', $session->read('Flash.flash'));
+        $this->set('flash', function () use ($session) {
+            $flash = $session->read('Flash.flash');
 
-        $session->delete('Flash');
+            $session->delete('Flash');
+
+            return $flash;
+        });
     }
 }

--- a/src/View/BaseViewTrait.php
+++ b/src/View/BaseViewTrait.php
@@ -1,8 +1,8 @@
 <?php
 namespace Inertia\View;
 
-use Closure;
 use Cake\Routing\Router;
+use Closure;
 
 trait BaseViewTrait
 {

--- a/src/View/BaseViewTrait.php
+++ b/src/View/BaseViewTrait.php
@@ -1,6 +1,7 @@
 <?php
 namespace Inertia\View;
 
+use Closure;
 use Cake\Routing\Router;
 
 trait BaseViewTrait
@@ -60,7 +61,13 @@ trait BaseViewTrait
                 continue;
             }
 
-            $props[$varName] = $passedViewVars[$varName];
+            $prop = $passedViewVars[$varName];
+
+            if ($prop instanceof Closure) {
+                $props[$varName] = $prop();
+            } else {
+                $props[$varName] = $prop;
+            }
         }
 
         return $props;


### PR DESCRIPTION
This plugin will now lazily evaluate props. To leverage this functionality one just have to pass the prop as a `Closure` instance and it will automatically evaluate for you to use.