### PR TITLE
Pass csrf token value

### DIFF
--- a/src/Controller/InertiaResponseTrait.php
+++ b/src/Controller/InertiaResponseTrait.php
@@ -19,6 +19,8 @@ trait InertiaResponseTrait
         $this->setViewBuilderClass();
 
         $this->setFlashData();
+
+        $this->setCsrfToken();
     }
 
     /**
@@ -97,5 +99,15 @@ trait InertiaResponseTrait
 
             return $flash;
         });
+    }
+
+    /**
+     * Sets `_csrfToken` field to pass into every front-end component.
+     *
+     * @return void
+     */
+    private function setCsrfToken()
+    {
+        $this->set('_csrfToken', $this->getRequest()->getParam('_csrfToken'));
     }
 }

--- a/tests/TestCase/Controller/UsersControllerTest.php
+++ b/tests/TestCase/Controller/UsersControllerTest.php
@@ -84,6 +84,7 @@ class UsersControllerTest extends TestCase
 
     public function testItRedirectsWithSeeOtherResponseCode()
     {
+        $this->enableCsrfToken();
         $this->configRequest([
             'headers' => ['X-Inertia' => 'true'],
         ]);
@@ -159,5 +160,19 @@ class UsersControllerTest extends TestCase
             'element' => 'flash-error',
             'params' => [],
         ], $responseArray['props']['flash']);
+    }
+
+    public function testPropsContainsCsrfToken()
+    {
+        $this->configRequest([
+            'headers' => ['X-Inertia' => 'true'],
+        ]);
+
+        $this->get('/users/index');
+        $responseArray = json_decode($this->_getBodyAsString(), true);
+
+        $this->assertResponseOk();
+        $this->assertArrayHasKey('_csrfToken', $responseArray['props']);
+        $this->assertNotEmpty($responseArray['props']['_csrfToken']);
     }
 }

--- a/tests/test_app/config/routes.php
+++ b/tests/test_app/config/routes.php
@@ -1,11 +1,18 @@
 <?php
 
+use Cake\Http\Middleware\CsrfProtectionMiddleware;
+use Cake\Routing\Route\DashedRoute;
 use Cake\Routing\RouteBuilder;
 use Cake\Routing\Router;
-use Cake\Routing\Route\DashedRoute;
 
 Router::reload();
 
 Router::scope('/', function (RouteBuilder $routes) {
+    // Register scoped middleware for in scopes.
+    $routes->registerMiddleware('csrf', new CsrfProtectionMiddleware([
+        'httpOnly' => true,
+    ]));
+    $routes->applyMiddleware('csrf');
+
     $routes->fallbacks(DashedRoute::class);
 });

--- a/tests/test_app/config/routes.php
+++ b/tests/test_app/config/routes.php
@@ -1,9 +1,9 @@
 <?php
 
 use Cake\Http\Middleware\CsrfProtectionMiddleware;
-use Cake\Routing\Route\DashedRoute;
 use Cake\Routing\RouteBuilder;
 use Cake\Routing\Router;
+use Cake\Routing\Route\DashedRoute;
 
 Router::reload();
 


### PR DESCRIPTION
Application now using this plugin will now not have to set CSRF token value manually instead this plugin now sets `_csrfToken` field value by default so it can be used by front-end to pass this value while making form request to prevent CSRF.

In front-end, it can be accessed via `this.$page._csrfToken` key.