### PR TITLE
Set variables for CakePHP and Inertia components

### DIFF
--- a/docs/ServerSideSetup.md
+++ b/docs/ServerSideSetup.md
@@ -110,6 +110,53 @@ $this->Flash->success('It worked!');
 
 That's it! The flash data will automatically pass to component as a `Array` for you to use.
 
+### Integrating Inertia into an Existing CakePHP Application
+
+To integrate Inertia into an existing CakePHP application you may want to use CakePHP elements such as HTML dynamic menus on part of the page while the Inertia Vue|React frontend components look after the rest of the page. 
+
+To enable this you need to tell the Inertia plugin NOT to bundle some variables needed by CakePHP elements by setting the `nonInertiaVars` view option.
+
+In a Controller Action or `beforeRender` method set the `nonInertiaVars` option to a string for a single variable or an array of variable names (see example below).
+
+Inertia will not bundle the view variables specified in `nonInertiaVars` into the Inertia div and they will be available to the CakePHP layouts and templates you are using to load the Inertia `div`.
+
+
+```php
+   // in a controller action or beforeRender method
+    public function index()
+    {
+        // these are the Inertia variables
+        $this->set('users', $this->Users->find()->toArray());
+        $this->set('edit_route', Router::pathUrl('Users::edit'));
+        $this->set('component', 'Users/Listing');
+
+        // these are CakePHP layout / template view variables
+        $this->set('companyName', 'My Company Name');
+        $this->set('isAdmin', true);
+        $this->set('loggedInUser',  $this->Authentication->getIdentity());
+
+        // specify either an array of variables
+        $this->viewBuilder()->setOption(
+            'nonInertiaVars',
+            [
+                "companyName",
+                'isAdmin',
+                'loggedInUser'
+            ]
+        );
+
+        // or a single field name
+        // $this->viewBuilder()->setOption('nonInertiaVars', 'loggedInUser');
+    }
+ 
+
+```
+
+
+
+
+
+
 ---
 
 [< Installation](Installation.md) | [Client-side Setup >](ClientSideSetup.md)

--- a/docs/ServerSideSetup.md
+++ b/docs/ServerSideSetup.md
@@ -107,55 +107,58 @@ To pass flash data into the front-end component, you simply have to set flash me
 ```php
 $this->Flash->success('It worked!');
 ```
-
 That's it! The flash data will automatically pass to component as a `Array` for you to use.
 
-### Integrating Inertia into an Existing CakePHP Application
+### Integrating Inertia with CakePHP layout and template elements
 
-To integrate Inertia into an existing CakePHP application you may want to use CakePHP elements such as HTML dynamic menus on part of the page while the Inertia Vue|React frontend components look after the rest of the page. 
+To include a mix of legacy CakePHP elements (such as a menu system) with Inertia components tell Inertia which view variables NOT to include in the root Inertia `div` using the `$_nonInteriaProps` class property
 
-To enable this you need to tell the Inertia plugin NOT to bundle some variables needed by CakePHP elements by setting the `nonInertiaVars` view option.
-
-In a Controller Action or `beforeRender` method set the `nonInertiaVars` option to a string for a single variable or an array of variable names (see example below).
-
-Inertia will not bundle the view variables specified in `nonInertiaVars` into the Inertia div and they will be available to the CakePHP layouts and templates you are using to load the Inertia `div`.
+In `AppController` (to globally set the Non-Interia vars) or a child that inherits from it (to make the change per Controller) set the `$_nonInertiaProps` class property to an array of View Vars:
 
 
 ```php
-   // in a controller action or beforeRender method
-    public function index()
-    {
-        // these are the Inertia variables
-        $this->set('users', $this->Users->find()->toArray());
-        $this->set('edit_route', Router::pathUrl('Users::edit'));
-        $this->set('component', 'Users/Listing');
+<?php
 
-        // these are CakePHP layout / template view variables
-        $this->set('companyName', 'My Company Name');
-        $this->set('isAdmin', true);
-        $this->set('loggedInUser',  $this->Authentication->getIdentity());
+namespace App\Controller;
 
-        // specify either an array of variables
-        $this->viewBuilder()->setOption(
-            'nonInertiaVars',
-            [
-                "companyName",
-                'isAdmin',
-                'loggedInUser'
-            ]
-        );
+use Cake\Core\Configure
+use Cake\Event\EventInterface;
+use Inertia\Controller\InertiaResponseTrait;
 
-        // or a single field name
-        // $this->viewBuilder()->setOption('nonInertiaVars', 'loggedInUser');
+class ExamplesController extends AppController
+{
+    // use a class property
+    protected array $_nonInertiaProps = [
+            'menu',
+            'user'
+    ];
+
+    // Or read from your configuration 
+    // in the `initialize` method
+    // public function initialize(): void
+    // {
+    //     parent::initialize();
+    //
+    //     $this->_nonInertiaProps = Configure::read('NON_INERTIA_PROPS')
+    // }
+
+    // See `Customize beforeRender hook` regarding further customization
+
+    public function index() {
+        // menu array
+        $menu = $this->Examples->Menus->find('threaded');
+
+        // user info to display logged in user in menu
+        $user = $this->Authentication->getIndentity();
+
+        $examples = $this->Examples->find('all);
+
+        // `menu` and `user` will be available to CakePHP view elements
+        // `examples` will be available to Inertia Components
+        $this->set(compact('menu', 'user', 'examples'));
     }
- 
-
+}
 ```
-
-
-
-
-
 
 ---
 

--- a/src/Controller/InertiaResponseTrait.php
+++ b/src/Controller/InertiaResponseTrait.php
@@ -27,7 +27,8 @@ trait InertiaResponseTrait
     }
 
     /**
-     * Sets _nonInertiaProps option to view so they wont be included in page
+     * Sets array of view variables for Inertia to ignore for use
+     * by Non-Inertia view elements
      *
      * @return void
      */
@@ -43,7 +44,8 @@ trait InertiaResponseTrait
             $nonInertiaProps = [$nonInertiaProps];
         }
 
-        $this->viewbuilder()->setOption('_nonInertiaProps', $nonInertiaProps);
+        $this->viewbuilder()
+            ->setOption('_nonInertiaProps', $nonInertiaProps);
     }
 
     /**

--- a/src/Controller/InertiaResponseTrait.php
+++ b/src/Controller/InertiaResponseTrait.php
@@ -22,6 +22,28 @@ trait InertiaResponseTrait
         $this->setFlashData();
 
         $this->setCsrfToken();
+
+        $this->setNonInertiaProps();
+    }
+
+    /**
+     * Sets _nonInertiaProps option to view so they wont be included in page
+     *
+     * @return void
+     */
+    private function setNonInertiaProps(): void
+    {
+        if (!property_exists($this, '_nonInertiaProps')) {
+            return;
+        }
+
+        $nonInertiaProps = $this->_nonInertiaProps;
+
+        if (is_string($nonInertiaProps)) {
+            $nonInertiaProps = [$nonInertiaProps];
+        }
+
+        $this->viewbuilder()->setOption('_nonInertiaProps', $nonInertiaProps);
     }
 
     /**
@@ -88,7 +110,7 @@ trait InertiaResponseTrait
         $session = $this->getRequest()->getSession();
 
         $this->set('flash', function () use ($session) {
-            if (! $session->check('Flash.flash.0')) {
+            if (!$session->check('Flash.flash.0')) {
                 return [];
             }
 

--- a/src/View/InertiaJsonView.php
+++ b/src/View/InertiaJsonView.php
@@ -24,9 +24,8 @@ class InertiaJsonView extends JsonView
         ];
 
         $this->setConfig('serialize', 'page');
-        $this->set([
-            'page' => $page,
-        ]);
+
+        $this->set(compact('page'));
 
         return parent::render($view, $layout);
     }

--- a/tests/TestCase/View/InertiaWebViewTest.php
+++ b/tests/TestCase/View/InertiaWebViewTest.php
@@ -6,10 +6,13 @@ namespace Inertia\Test\TestCase\View;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
+use Cake\View\ViewBuilder;
 use Inertia\View\InertiaWebView;
 
 class InertiaWebViewTest extends TestCase
 {
+    public InertiaWebView $View;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -37,5 +40,52 @@ class InertiaWebViewTest extends TestCase
         $result = $this->View->render();
 
         $this->assertStringContainsString('&quot;Users\/Index&quot', $result);
+    }
+
+    public function createViewBuilderForPassThru()
+    {
+        $request = new ServerRequest();
+        $response = new Response();
+
+        $this->View = (new ViewBuilder())
+            ->setClassName('Inertia\View\InertiaWebView')
+            ->setOption('_nonInertiaProps', ['one', 'two', 'three'])
+            ->build([], $request, $response);
+    }
+
+    public function testItCanPassthruVarsToCake()
+    {
+        $this->createViewBuilderForPassThru();
+
+        $this->View->set('component', 'Users/Index');
+        $this->View->set('user', ['id' => 1, 'name' => 'John Doe']);
+        $this->View->set('one', 1);
+        $this->View->set('two', 2);
+        $this->View->set('three', 3);
+
+        $actual = $this->View->getVars();
+
+        $expected = [
+            'three',
+            'two',
+            'one',
+            'user',
+            'component',
+        ];
+
+        $this->assertEquals($expected, $actual);
+
+        $result = $this->View->render();
+
+        $actual = $this->View->getVars();
+
+        $expected = [
+            'page',
+            'three',
+            'two',
+            'one',
+        ];
+
+        $this->assertEquals($expected, $actual);
     }
 }

--- a/tests/TestCase/View/InertiaWebViewTest.php
+++ b/tests/TestCase/View/InertiaWebViewTest.php
@@ -19,7 +19,11 @@ class InertiaWebViewTest extends TestCase
 
         $request = new ServerRequest();
         $response = new Response();
-        $this->View = new InertiaWebView($request, $response);
+
+        $this->View = (new ViewBuilder())
+            ->setClassName('Inertia\View\InertiaWebView')
+            ->setOption('_nonInertiaProps', ['one', 'two', 'three'])
+            ->build([], $request, $response);
     }
 
     public function testRendersDivWithIdAppAttribute()
@@ -42,21 +46,8 @@ class InertiaWebViewTest extends TestCase
         $this->assertStringContainsString('&quot;Users\/Index&quot', $result);
     }
 
-    public function createViewBuilderForPassThru()
-    {
-        $request = new ServerRequest();
-        $response = new Response();
-
-        $this->View = (new ViewBuilder())
-            ->setClassName('Inertia\View\InertiaWebView')
-            ->setOption('_nonInertiaProps', ['one', 'two', 'three'])
-            ->build([], $request, $response);
-    }
-
     public function testItCanPassthruVarsToCake()
     {
-        $this->createViewBuilderForPassThru();
-
         $this->View->set('component', 'Users/Index');
         $this->View->set('user', ['id' => 1, 'name' => 'John Doe']);
         $this->View->set('one', 1);


### PR DESCRIPTION
Hi Ishan,

I barely know how to submit a PR so I hope I have done this right. Please let me know how I can do it better if this is not right.

I have added the ability to specify viewVars that should not be included in the inertia div and instead be available to whichever layout/template is being served by InertiaWebView.

This allows integrating the inertia part of a page with a legacy navbar / menu.


