### PR TITLE
Improve compatibility with CakePHP 4.5 and PHP 8.2

### DIFF
--- a/src/Middleware/InertiaMiddleware.php
+++ b/src/Middleware/InertiaMiddleware.php
@@ -21,11 +21,11 @@ class InertiaMiddleware implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        if (!$request->hasHeader('X-Inertia')) {
-            return $handler->handle($request);
-        }
         if ($request instanceof ServerRequest) {
             $this->setupDetectors($request);
+        }
+        if (!$request->hasHeader('X-Inertia')) {
+            return $handler->handle($request);
         }
 
         $response = $handler->handle($request);

--- a/tests/TestCase/View/InertiaJsonViewTest.php
+++ b/tests/TestCase/View/InertiaJsonViewTest.php
@@ -10,6 +10,8 @@ use Inertia\View\InertiaJsonView;
 
 class InertiaJsonViewTest extends TestCase
 {
+    public $View;
+
     public function setUp(): void
     {
         parent::setUp();


### PR DESCRIPTION
- `ServerRequest::is()` now throws exceptions when a detector is unregistered.
- PHP 8.2 emits deprecations for dynamically created properties.